### PR TITLE
Initialize summarizer pipeline

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,0 +1,23 @@
+name: Monthly Review
+on:
+  schedule:
+    - cron: '0 1 1 * *'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: pip install -r requirements.txt
+      - name: Run monthly summary
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DB_ID: ${{ secrets.NOTION_DB_ID }}
+          DEEPSEEK_KEY: ${{ secrets.DEEPSEEK_KEY }}
+        run: python src/main.py --period monthly

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,23 @@
+name: Weekly Review
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: pip install -r requirements.txt
+      - name: Run weekly summary
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DB_ID: ${{ secrets.NOTION_DB_ID }}
+          DEEPSEEK_KEY: ${{ secrets.DEEPSEEK_KEY }}
+        run: python src/main.py --period weekly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+requests

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
-# src/main.py
-import argparse, notion_client, summarizer, llm_client, os
+import argparse
+import os
+import notion_client
+import summarizer
+import llm_client
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--period", choices=["daily","weekly","monthly"])
+parser.add_argument("--period", choices=["daily", "weekly", "monthly"], required=True)
 args = parser.parse_args()
 
 db_id = os.getenv("NOTION_DB_ID")
@@ -10,5 +13,14 @@ db_id = os.getenv("NOTION_DB_ID")
 if args.period == "daily":
     tasks = notion_client.query_today_tasks(db_id)
     prompt = summarizer.build_daily_prompt(tasks)
-    answer = llm_client.ask_llm(prompt)
-    print(answer)                     # 后续可写回 Notion / 发邮件
+elif args.period == "weekly":
+    tasks = notion_client.query_this_week_tasks(db_id)
+    prompt = summarizer.build_weekly_prompt(tasks)
+elif args.period == "monthly":
+    tasks = notion_client.query_this_month_tasks(db_id)
+    prompt = summarizer.build_monthly_prompt(tasks)
+else:
+    raise ValueError("Unsupported period")
+
+answer = llm_client.ask_llm(prompt)
+print(answer)

--- a/src/notion_client.py
+++ b/src/notion_client.py
@@ -1,0 +1,75 @@
+import os
+import datetime
+import requests
+
+TOKEN = os.getenv("NOTION_TOKEN")
+HEADERS = {
+    "Authorization": f"Bearer {TOKEN}",
+    "Notion-Version": "2022-06-28",
+    "Content-Type": "application/json",
+}
+
+
+def _query_tasks(db_id: str, start: datetime.date, end: datetime.date):
+    payload = {
+        "filter": {
+            "and": [
+                {
+                    "property": "\u8ba1\u5212\u65e5\u671f",
+                    "date": {
+                        "on_or_after": start.isoformat(),
+                    },
+                },
+                {
+                    "property": "\u8ba1\u5212\u65e5\u671f",
+                    "date": {
+                        "on_or_before": end.isoformat(),
+                    },
+                },
+                {
+                    "property": "\u72b6\u6001",
+                    "select": {"equals": "Done"},
+                },
+            ]
+        }
+    }
+    r = requests.post(
+        f"https://api.notion.com/v1/databases/{db_id}/query",
+        headers=HEADERS,
+        json=payload,
+    )
+    r.raise_for_status()
+    return r.json().get("results", [])
+
+
+def query_today_tasks(db_id: str):
+    today = datetime.date.today()
+    return _query_tasks(db_id, today, today)
+
+
+def query_this_week_tasks(db_id: str):
+    today = datetime.date.today()
+    start = today - datetime.timedelta(days=today.weekday())
+    end = start + datetime.timedelta(days=6)
+    return _query_tasks(db_id, start, end)
+
+
+def query_this_month_tasks(db_id: str):
+    today = datetime.date.today()
+    start = today.replace(day=1)
+    if start.month == 12:
+        next_month = datetime.date(start.year + 1, 1, 1)
+    else:
+        next_month = datetime.date(start.year, start.month + 1, 1)
+    end = next_month - datetime.timedelta(days=1)
+    return _query_tasks(db_id, start, end)
+
+
+def calc_xp(page):
+    pri = (
+        page.get("properties", {})
+        .get("\u4f18\u5148\u7ea7", {})
+        .get("select", {})
+        .get("name")
+    )
+    return 10 if pri == "MIT" else 5

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1,21 +1,37 @@
-# src/summarizer.py
-def build_daily_prompt(tasks):
+from notion_client import calc_xp
+
+
+def _build_prompt(header: str, tasks, highlight_period: str, next_period: str) -> str:
     total = len(tasks)
     xp = sum(calc_xp(t) for t in tasks)
     cats = {}
     for t in tasks:
-        c = t["properties"]["分类"]["select"]["name"]
+        c = t["properties"]["\u5206\u7c7b"]["select"]["name"]
         cats[c] = cats.get(c, 0) + 1
-    cat_lines = ", ".join(f"{k}:{v}" for k,v in cats.items())
-    task_titles = "\n".join(f"- {t['properties']['任务名称']['title'][0]['plain_text']}"
-                            for t in tasks)
+    cat_lines = ", ".join(f"{k}:{v}" for k, v in cats.items())
+    task_titles = "\n".join(
+        f"- {t['properties']['\u4efb\u52a1\u540d\u79f0']['title'][0]['plain_text']}"
+        for t in tasks
+    )
+    return (
+        f"# {header}\n"
+        f"\u5df2\u5b8c\u6210\u4efb\u52a1 {total} \u4e2a\uff0c\u5206\u7c7b\u5206\u5e03\uff1a{cat_lines}\uff0c\u83b7\u5f97 XP {xp}\u3002\n"
+        f"## \u4efb\u52a1\u6e05\u5355\n"
+        f"{task_titles}\n\n"
+        f"\u8bf7\u7528\u4e2d\u6587\u8f93\u51fa\uff1a\n"
+        f"1. \u5f52\u7ed3{highlight_period} 3 \u4e2a\u4eae\u70b9\n"
+        f"2. 1 \u4e2a\u6700\u5927\u6539\u8fdb\u70b9\n"
+        f"3. {next_period} 3 \u6761\u884c\u52a8\u5efa\u8bae\uff08\u4fdd\u6301\u5177\u4f53\u53ef\u6267\u884c\uff09"
+    )
 
-    return f"""# Daily Review
-已完成任务 {total} 个，分类分布：{cat_lines}，获得 XP {xp}。
-## 任务清单
-{task_titles}
 
-请用中文输出：
-1. 归纳今天 3 个亮点
-2. 1 个最大改进点
-3. 明天 3 条行动建议（保持具体可执行）"""
+def build_daily_prompt(tasks):
+    return _build_prompt("Daily Review", tasks, "\u4eca\u5929", "\u660e\u5929")
+
+
+def build_weekly_prompt(tasks):
+    return _build_prompt("Weekly Review", tasks, "\u672c\u5468", "\u4e0b\u5468")
+
+
+def build_monthly_prompt(tasks):
+    return _build_prompt("Monthly Review", tasks, "\u672c\u6708", "\u4e0b\u6708")


### PR DESCRIPTION
## Summary
- add helper for querying Notion and computing task XP
- generate prompts for daily, weekly and monthly reviews
- handle all periods in main entrypoint
- schedule weekly and monthly workflows
- specify openai/requests dependencies

## Testing
- `python -m py_compile src/*.py`
- `pytest -q`
