### PR TITLE
Add script to import task breakdown to GitHub Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,21 @@ pytest tests/ -v
 - 任务查询结果
 - AI 调用状态  
 - 通知发送结果
+## Import Tasks to GitHub Project
+
+项目提供 `scripts/import_tasks_to_project.py` 脚本，可将 `tasks_phase1.yml` 中的任务批量创建为 Issue 并加入指定的 Project 列，便于集中管理。
+
+### 使用方法
+1. 准备 GitHub Token 并设置环境变量 `GITHUB_TOKEN`
+2. 设置 `GITHUB_REPO`（例如 `my-org/my-repo`）
+3. 设置 `GITHUB_COLUMN_ID` 为目标 Project 列 ID
+4. 运行
+
+```bash
+python scripts/import_tasks_to_project.py tasks_phase1.yml
+```
+
+
 
 ## 🤝 贡献指南
 

--- a/scripts/import_tasks_to_project.py
+++ b/scripts/import_tasks_to_project.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Import tasks from YAML into GitHub Project (classic)."""
+import os
+import sys
+import yaml
+import requests
+
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+REPO = os.getenv("GITHUB_REPO")  # e.g. "org/repo"
+COLUMN_ID = os.getenv("GITHUB_COLUMN_ID")  # project column id
+
+if not all([GITHUB_TOKEN, REPO, COLUMN_ID]):
+    print("Environment variables GITHUB_TOKEN, GITHUB_REPO, GITHUB_COLUMN_ID are required")
+    sys.exit(1)
+
+headers = {
+    "Authorization": f"token {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github.v3+json",
+}
+
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} <tasks.yml>")
+    sys.exit(1)
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = yaml.safe_load(f)
+
+tasks = data.get("tasks", [])
+
+for task in tasks:
+    title = f"{task['id']} - {task['title']}"
+    body = (
+        f"**Owner**: {task['owner']}\n"
+        f"**Effort**: {task['effort']}\n"
+        f"**Depends**: {task.get('depends', '')}\n"
+        f"**Acceptance Criteria**: {task['acceptance']}"
+    )
+
+    # create issue
+    issue_url = f"https://api.github.com/repos/{REPO}/issues"
+    issue_resp = requests.post(issue_url, headers=headers, json={"title": title, "body": body})
+    issue_resp.raise_for_status()
+    issue_number = issue_resp.json()["number"]
+
+    # add issue to project column
+    card_url = f"https://api.github.com/projects/columns/{COLUMN_ID}/cards"
+    card_resp = requests.post(card_url, headers=headers, json={"content_id": issue_number, "content_type": "Issue"})
+    card_resp.raise_for_status()
+
+    print(f"Created issue #{issue_number} and added to project column {COLUMN_ID}")

--- a/tasks_phase1.yml
+++ b/tasks_phase1.yml
@@ -1,0 +1,193 @@
+tasks:
+- id: P1-01
+  title: "Schedule & Run Kick-off Meeting"
+  owner: TL
+  effort: "2h"
+  depends: ""
+  acceptance: "所有人加入；会议纪要发布到 Confluence"
+- id: P1-02
+  title: "Create Project Board"
+  owner: TL
+  effort: "1h"
+  depends: P1-01
+  acceptance: "板已创建并邀请全员"
+- id: P1-03
+  title: "Clone Legacy Repo"
+  owner: DEVOPS
+  effort: "1h"
+  depends: P1-01
+  acceptance: "Repo 可拉取；Commit 历史完整"
+- id: P1-04
+  title: "Asset Scanner Script"
+  owner: DEVOPS
+  effort: "4h"
+  depends: P1-03
+  acceptance: "运行 `python scripts/asset_scanner.py > report.csv` 生成 100% 文件清单"
+- id: P1-05
+  title: "Unit Test Asset Scanner"
+  owner: DEVOPS
+  effort: "1h"
+  depends: P1-04
+  acceptance: "pytest -k test_asset_scanner 通过"
+- id: P1-06
+  title: "Rate Legacy Tech Debt"
+  owner: TL
+  effort: "3h"
+  depends: P1-04
+  acceptance: "debt.md 推送到仓库"
+- id: P1-07
+  title: "Draft Domain Model (Miro)"
+  owner: BE-A
+  effort: "4h"
+  depends: P1-01
+  acceptance: "图片链接贴到 ticket"
+- id: P1-08
+  title: "Review & Freeze Model v0.1"
+  owner: ALL
+  effort: "1h"
+  depends: P1-07
+  acceptance: "评论全部解决，TL 打 tag `domain-v0.1`"
+- id: P1-09
+  title: "Select Core Libraries"
+  owner: TL
+  effort: "2h"
+  depends: P1-08
+  acceptance: "wiki/stack-decision.md 完成"
+- id: P1-10
+  title: "Init New Repo (tm-ai) with main branch"
+  owner: DEVOPS
+  effort: "1h"
+  depends: P1-09
+  acceptance: "git clone 可用"
+- id: P1-11
+  title: "Add Base Files"
+  owner: DEVOPS
+  effort: "1h"
+  depends: P1-10
+  acceptance: "Files 在 root，CI 过"
+- id: P1-12
+  title: "Configure Pre-commit"
+  owner: DEVOPS
+  effort: "2h"
+  depends: P1-10
+  acceptance: "pre-commit run --all-files 0 error"
+- id: P1-13
+  title: "Create Docker-Compose Dev"
+  owner: DEVOPS
+  effort: "4h"
+  depends: P1-10
+  acceptance: "docker compose up -d 所有容器 healthy"
+- id: P1-14
+  title: "Skeleton Package Tree"
+  owner: BE-A
+  effort: "2h"
+  depends: P1-10
+  acceptance: "目录结构 push，import 不报错"
+- id: P1-15
+  title: "Implement Workspace Model"
+  owner: BE-A
+  effort: "2h"
+  depends: P1-14
+  acceptance: "Alembic migration passes; fields对齐模型图"
+- id: P1-16
+  title: "Write BaseIntegration ABC"
+  owner: BE-A
+  effort: "1h"
+  depends: P1-14
+  acceptance: "mypy 无警告"
+- id: P1-17
+  title: "Port Notion Adapter (read-only)"
+  owner: BE-B
+  effort: "4h"
+  depends: P1-16
+  acceptance: "可调用 `list_tasks('daily')` 返回 list[Task]"
+- id: P1-18
+  title: "Command-line PoC"
+  owner: BE-B
+  effort: "2h"
+  depends: "P1-17, P1-15"
+  acceptance: "Demo 视频 30s 上传"
+- id: P1-19
+  title: "Pytest Config & Coverage"
+  owner: DEVOPS
+  effort: "1h"
+  depends: P1-10
+  acceptance: "pytest 0 failed"
+- id: P1-20
+  title: "CI Pipeline v0"
+  owner: DEVOPS
+  effort: "2h"
+  depends: "P1-19 P1-12"
+  acceptance: "CI 绿灯，时长 < 10 min"
+- id: P1-21
+  title: "Encrypt Notion Token Field"
+  owner: BE-A
+  effort: "3h"
+  depends: P1-15
+  acceptance: "明文写入自动加密；单测通过"
+- id: P1-22
+  title: "Second Workspace Seed Script"
+  owner: BE-B
+  effort: "1h"
+  depends: P1-21
+  acceptance: "Seed 成功，两行记录"
+- id: P1-23
+  title: "Multi-Workspace Integration Test"
+  owner: QA
+  effort: "2h"
+  depends: "P1-18 P1-22"
+  acceptance: "pytest pass"
+- id: P1-24
+  title: "ADR-0001 — Tenant Model"
+  owner: TL
+  effort: "2h"
+  depends: P1-23
+  acceptance: "ADR 合并至 `/docs/adr-0001.md`"
+- id: P1-25
+  title: "Add Ruff + Mypy Strict to CI"
+  owner: DEVOPS
+  effort: "1h"
+  depends: P1-20
+  acceptance: "违反规则 push 会 fail"
+- id: P1-26
+  title: "429 Rate-Limit Experiment"
+  owner: QA
+  effort: "3h"
+  depends: P1-17
+  acceptance: "报告 metrics.csv 附图"
+- id: P1-27
+  title: "Implement Exponential Backoff Helper"
+  owner: BE-B
+  effort: "2h"
+  depends: P1-26
+  acceptance: "单测模拟 429 < 5 次重试成功"
+- id: P1-28
+  title: "Readme Quick-Start Guide"
+  owner: DEVOPS
+  effort: "1h"
+  depends: "P1-13 P1-18"
+  acceptance: "新人 30 min 内跑通"
+- id: P1-29
+  title: "Docker Image Publish (GHCR)"
+  owner: DEVOPS
+  effort: "2h"
+  depends: P1-20
+  acceptance: "docker pull … 成功"
+- id: P1-30
+  title: "Phase-End Demo Rehearsal"
+  owner: ALL
+  effort: "1h"
+  depends: "P1-18 P1-23"
+  acceptance: "Agenda 发出，演示脚本准备"
+- id: P1-31
+  title: "Live Demo & Recording"
+  owner: ALL
+  effort: "2h"
+  depends: P1-30
+  acceptance: "视频上传；TL 签字“Phase 1 Done”"
+- id: P1-32
+  title: "Retrospective & Action Items"
+  owner: ALL
+  effort: "1h"
+  depends: P1-31
+  acceptance: "Confluence 页面公开"


### PR DESCRIPTION
## Summary
- add `tasks_phase1.yml` listing the 32 phase 1 tasks
- add helper script `import_tasks_to_project.py` to create issues from the YAML and add them to a project column
- document how to use the script in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684dd24d8818832a8af48f93b2f9a208